### PR TITLE
decoupling of methods;  also more flexibility in parsing

### DIFF
--- a/src/main/java/com/xceptance/xlt/nocoding/parser/Parser.java
+++ b/src/main/java/com/xceptance/xlt/nocoding/parser/Parser.java
@@ -27,7 +27,20 @@ public interface Parser
      * @return The list of {@link Command}s that is described in the file
      * @throws IOException
      */
-    public abstract List<Command> parse(String pathToFile) throws IOException;
+    public default List<Command> parse(final String pathToFile) throws IOException
+    {
+        return parse(createReader(pathToFile));
+    }
+
+    /**
+     * Parses the content of the <code>reader</code> to a list of {@link Command}s
+     *
+     * @param reader
+     *            The Reader that contains {@link Command}s in a parser dependent format
+     * @return The list of {@link Command}s that is described in the reader
+     * @throws IOException
+     */
+    public abstract List<Command> parse(final Reader reader) throws IOException;
 
     /**
      * Returns all acceptable extensions for this Parser

--- a/src/main/java/com/xceptance/xlt/nocoding/parser/csv/CsvParser.java
+++ b/src/main/java/com/xceptance/xlt/nocoding/parser/csv/CsvParser.java
@@ -26,24 +26,22 @@ public class CsvParser implements Parser
 {
 
     /**
-     * Parses the content of the file at <code>pathToFile</code> to a list of {@link Command}s
+     * Parses the content of the Reader <code>reader</code> to a list of {@link Command}s
      *
-     * @param pathToFile
-     *            The String that describes the path to the file
+     * @param reader
+     *            The Reader that contains {@link Command}s in a parser dependent format
      * @return A list of {@link Command}s
      * @throws IOException
      *             if an I/O error occurs during creating the reader, parsing the file or closing the parser
      */
     @Override
-    public List<Command> parse(final String pathToFile) throws IOException
+    public List<Command> parse(final Reader reader) throws IOException
     {
         // Initialize variables
         final List<Command> scriptItems = new ArrayList<>();
         final ActionWrapper lastAction = new ActionWrapper();
         final StaticSubrequestWrapper lastStatic = new StaticSubrequestWrapper();
 
-        // Create a Reader based on the file
-        final Reader reader = createReader(pathToFile);
         // Create a CSVParser based on the Reader
         final CSVParser parser = new CSVParser(reader, CsvConstants.CSV_FORMAT.withFirstRecordAsHeader());
         try

--- a/src/main/java/com/xceptance/xlt/nocoding/parser/yaml/YamlParser.java
+++ b/src/main/java/com/xceptance/xlt/nocoding/parser/yaml/YamlParser.java
@@ -31,23 +31,23 @@ public class YamlParser implements Parser
 {
 
     /**
-     * Parses the content of the file at the <code>pathToFile</code> to a list of {@link Command}s
+     * Parses the content of the Reader <code>reader</code> to a list of {@link Command}s
      *
-     * @param pathToFile
-     *            The String that describes the path to the file
+     * @param reader
+     *            The Reader that contains {@link Command}s in a parser dependent format
      * @return A list of {@link Command}s
      * @throws IOException
      *             If a {@link Reader} or {@link JsonParser} cannot be created or the file cannot be mapped to a
      *             {@link JsonNode}.
      */
     @Override
-    public List<Command> parse(final String pathToFile) throws IOException
+    public List<Command> parse(final Reader reader) throws IOException
     {
         final List<Command> commands = new ArrayList<Command>();
         // Parse the Yaml with snakeyml
         final Yaml yaml = new Yaml();
         // final Object loadedYaml = yaml.load(createReader(pathToFile));
-        final Node root = yaml.compose(createReader(pathToFile));
+        final Node root = yaml.compose(reader);
         if (root instanceof SequenceNode)
         {
             final List<Node> commandWrappersList = ((SequenceNode) root).getValue();


### PR DESCRIPTION
Beside decoupling the parser methods this change also enables the usage of alternative (not directly file based) YAML sources:
now we can also call Parser.parse for example with a StringReader.