### PR TITLE
Configurable default http code validation

### DIFF
--- a/src/main/java/com/xceptance/xlt/nocoding/command/action/response/Response.java
+++ b/src/main/java/com/xceptance/xlt/nocoding/command/action/response/Response.java
@@ -1,11 +1,12 @@
 package com.xceptance.xlt.nocoding.command.action.response;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.gargoylesoftware.htmlunit.WebResponse;
 import com.xceptance.xlt.nocoding.command.action.AbstractActionSubItem;
+import com.xceptance.xlt.nocoding.util.NoCodingPropertyAdmin;
 import com.xceptance.xlt.nocoding.util.context.Context;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The expected response to a request. A response has a list of response items, which validate or store something of the
@@ -28,7 +29,6 @@ public class Response extends AbstractActionSubItem
     public Response()
     {
         this(new ArrayList<AbstractResponseSubItem>(1));
-        responseItems.add(new HttpCodeValidator(null));
     }
 
     /**
@@ -65,22 +65,21 @@ public class Response extends AbstractActionSubItem
     /**
      * Adds a {@link HttpCodeValidator} to the {@link #responseItems} if none is specified
      */
-    void fillDefaultData(final Context<?> context)
-    {
-        boolean hasHttpcodeValidator = false;
-        // Look for an instance of HttpcodeValidator
-        for (final AbstractResponseSubItem responseItem : responseItems)
-        {
-            if (responseItem instanceof HttpCodeValidator)
-            {
-                // If a HttpcodeValidator was found, set hasHttpcodeValidator to true
-                hasHttpcodeValidator = true;
+    void fillDefaultData(final Context<?> context) {
+        boolean defaultResponseCodeValidation = context.getPropertyByKey(NoCodingPropertyAdmin.DEFAULT_HTTP_CODE_VALIDATION, true);
+        if (defaultResponseCodeValidation){
+            boolean hasHttpcodeValidator = false;
+            // Look for an instance of HttpcodeValidator
+            for (final AbstractResponseSubItem responseItem : responseItems) {
+                if (responseItem instanceof HttpCodeValidator) {
+                    // If a HttpcodeValidator was found, set hasHttpcodeValidator to true
+                    hasHttpcodeValidator = true;
+                }
             }
-        }
-        // If no HttpcodeValidator was found, add one at the beginning
-        if (!hasHttpcodeValidator)
-        {
-            responseItems.add(0, new HttpCodeValidator(null));
+            // If no HttpcodeValidator was found, add one at the beginning
+            if (!hasHttpcodeValidator) {
+                responseItems.add(0, new HttpCodeValidator(null));
+            }
         }
     }
 

--- a/src/main/java/com/xceptance/xlt/nocoding/util/NoCodingPropertyAdmin.java
+++ b/src/main/java/com/xceptance/xlt/nocoding/util/NoCodingPropertyAdmin.java
@@ -1,10 +1,10 @@
 package com.xceptance.xlt.nocoding.util;
 
-import java.text.MessageFormat;
-
 import com.xceptance.xlt.api.util.XltLogger;
 import com.xceptance.xlt.api.util.XltProperties;
 import com.xceptance.xlt.engine.XltWebClient;
+
+import java.text.MessageFormat;
 
 /**
  * Handles all property related matters.
@@ -37,6 +37,8 @@ public class NoCodingPropertyAdmin
 
     public static final String DIRECTORY_DEFAULT = "./config/data/";
 
+    public static final String DEFAULT_HTTP_CODE_VALIDATION = "com.xceptance.xlt.nocoding.defaultHttpCodeValidation";
+
     public NoCodingPropertyAdmin(final XltProperties xltProperties)
     {
         this.xltProperties = xltProperties;
@@ -44,7 +46,7 @@ public class NoCodingPropertyAdmin
 
     /**
      * Sets whether redirects should be enabled or not.
-     * 
+     *
      * @param webClient
      *            The {@link XltWebClient} on which to set this property.
      */

--- a/src/test/java/com/xceptance/xlt/nocoding/command/action/response/ResponseTest.java
+++ b/src/test/java/com/xceptance/xlt/nocoding/command/action/response/ResponseTest.java
@@ -3,7 +3,9 @@ package com.xceptance.xlt.nocoding.command.action.response;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.xceptance.xlt.nocoding.util.NoCodingPropertyAdmin;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.xceptance.xlt.api.validators.HttpResponseCodeValidator;
@@ -26,6 +28,12 @@ public class ResponseTest extends AbstractContextTest
         mockObjects = new MockObjects();
         mockObjects.loadResponse();
         context.setWebResponse(mockObjects.getResponse());
+    }
+
+    @Before
+    public void beforeEach() {
+        // reset context to default: not set
+        context.getPropertyAdmin().getProperties().removeProperty(NoCodingPropertyAdmin.DEFAULT_HTTP_CODE_VALIDATION);
     }
 
     /**
@@ -78,4 +86,58 @@ public class ResponseTest extends AbstractContextTest
         Assert.assertEquals(httpcode, ((HttpCodeValidator) response.getResponseItems().get(0)).getHttpcode());
     }
 
+    /**
+     * Verifies no {@link HttpCodeValidator} is added when {@link Response#execute(Context)} is called and
+     * <code>com.xceptance.xlt.nocoding.defaultHttpCodeValidation</code> is set to false
+     *
+     * @throws Throwable
+     */
+    @Test
+    public void testFillDefaultWhenPropertyFalse() throws Throwable
+    {
+        final List<AbstractResponseSubItem> responseItems = new ArrayList<>();
+        final Response response = new Response(responseItems);
+        Assert.assertNull(context.getPropertyByKey(NoCodingPropertyAdmin.DEFAULT_HTTP_CODE_VALIDATION));
+        context.getPropertyAdmin().getProperties().setProperty(NoCodingPropertyAdmin.DEFAULT_HTTP_CODE_VALIDATION, "false");
+        response.execute(context);
+        Assert.assertNotNull(response.getResponseItems());
+        Assert.assertEquals(0, response.getResponseItems().size());
+    }
+
+    /**
+     * Verifies {@link HttpCodeValidator} is present when {@link Response#execute(Context)} is called and
+     * <code>com.xceptance.xlt.nocoding.defaultHttpCodeValidation</code> is not set
+     *
+     * @throws Throwable
+     */
+    @Test
+    public void testFillDefaultWhenPropertyMissing() throws Throwable
+    {
+        final List<AbstractResponseSubItem> responseItems = new ArrayList<>();
+        final Response response = new Response(responseItems);
+        Assert.assertNull(context.getPropertyByKey(NoCodingPropertyAdmin.DEFAULT_HTTP_CODE_VALIDATION));
+        response.execute(context);
+        Assert.assertNotNull(response.getResponseItems());
+        Assert.assertEquals(1, response.getResponseItems().size());
+        Assert.assertTrue(response.getResponseItems().get(0) instanceof HttpCodeValidator);
+    }
+
+    /**
+     * Verifies {@link HttpCodeValidator} is present when {@link Response#execute(Context)} is called and
+     * <code>com.xceptance.xlt.nocoding.defaultHttpCodeValidation</code> is set to true
+     *
+     * @throws Throwable
+     */
+    @Test
+    public void testFillDefaultWhenPropertyTrue() throws Throwable
+    {
+        final List<AbstractResponseSubItem> responseItems = new ArrayList<>();
+        final Response response = new Response(responseItems);
+        Assert.assertNull(context.getPropertyByKey(NoCodingPropertyAdmin.DEFAULT_HTTP_CODE_VALIDATION));
+        context.getPropertyAdmin().getProperties().setProperty(NoCodingPropertyAdmin.DEFAULT_HTTP_CODE_VALIDATION, "true");
+        response.execute(context);
+        Assert.assertNotNull(response.getResponseItems());
+        Assert.assertEquals(1, response.getResponseItems().size());
+        Assert.assertTrue(response.getResponseItems().get(0) instanceof HttpCodeValidator);
+    }
 }


### PR DESCRIPTION
We run XLT NoCoding load tests, in which we do not want to check by default whether the return code of the requests is 200. So far we have not been able to switch off this check, so we have made a small adjustment in XLT NoCoding.

Therefore we've created a new property com.xceptance.xlt.nocoding.defaultHttpCodeValidation for configuring if a default Httpcode validation (HttpCodeValidator) in the Response class should be added.